### PR TITLE
Use only pass_for_claim field to generate secret

### DIFF
--- a/src/pages/claim/claim.tsx
+++ b/src/pages/claim/claim.tsx
@@ -38,7 +38,6 @@ const enhancer = (Component: React.ComponentType<Props>) => (props: RouterProps)
         lifecycle(
           {
             componentDidMount: async () => {
-              const username: string = get(routerProps.location, "state.username", "");
               const userData: any = get(routerProps.location, "state.userData", "");
               const passwordHash = userData.pass_for_claim;
               const firstName =
@@ -51,8 +50,7 @@ const enhancer = (Component: React.ComponentType<Props>) => (props: RouterProps)
                   : null;
               let contract;
               let balance;
-              const secretHash = createSecret(username, passwordHash, true);
-              const secret = createSecret(username, passwordHash);
+              const [secret, secretHash] = createSecret(passwordHash);
 
               try {
                 contract = await getContractAddress("Investments");

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,10 +10,8 @@ export function isHexadecimal(str: string) {
   }
 }
 
-export function createSecret(userName: string, passwordHash: string, secretHash?: boolean) {
-  const hexStr = utils.str2hexstr(String.prototype.concat(userName, passwordHash));
-  if (secretHash) {
-    return utils.sha256(utils.sha256(hexStr));
-  }
-  return utils.sha256(hexStr);
+export function createSecret(passwordHash: string) {
+  const hexStr = utils.str2hexstr(passwordHash);
+  const secret = utils.sha256(hexStr);
+  return [secret, utils.sha256(secret)];
 }


### PR DESCRIPTION
To enable a claim for investors with changed usernames, we will keep both original username and original pass_hash in field pass_for_claim