### PR TITLE
Onxp 113 wrong amount of sent oep 4 token is displayed in transaction info

### DIFF
--- a/src/pages/sendConfirm/sendConfirm.tsx
+++ b/src/pages/sendConfirm/sendConfirm.tsx
@@ -58,12 +58,10 @@ const enhancer = (Component: React.ComponentType<Props>) => (props: RouteCompone
                 transferToken(reduxProps.wallet, password, recipient, asset, amount),
                 15000
               );
-              const tokenDecimals = reduxProps.tokens.find(t => t.symbol === asset);
               props.history.push("/sendComplete", {
                 recipient,
                 asset,
                 amount,
-                decimals: tokenDecimals && tokenDecimals.decimals
               });
             }
           } catch (e) {


### PR DESCRIPTION
[ONXP-113](https://scaddr.apriorit.com/jira/browse/ONXP-113) [Wallet][OEP-4] Wrong amount of sent OEP-4 token is displayed in transaction info:
 
- deleted passing decimals value if transaction has ended successfully since now api converts value to correct ones automatically